### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for Terrakube operations, enabling workspace management, variable handling, module operations, and organization management.
 
+<a href="https://glama.ai/mcp/servers/@AzBuilder/mcp-server-terrakube">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AzBuilder/mcp-server-terrakube/badge" alt="Terrakube Server MCP server" />
+</a>
+
 ## Features
 
 - **Comprehensive API Integration**: Full integration with Terrakube's API for seamless operations


### PR DESCRIPTION
This PR adds a badge for the [Terrakube MCP Server](https://glama.ai/mcp/servers/@AzBuilder/mcp-server-terrakube) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@AzBuilder/mcp-server-terrakube">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AzBuilder/mcp-server-terrakube/badge" alt="Terrakube Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.